### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ deepdiff==5.6.0
 discord.py==2.1.1
 PyYAML==6.0
 requests==2.25.1
-substrateinterface==1.3.3
+substrate-interface==1.7.4


### PR DESCRIPTION
substrateinterface was renamed to substrate-interface and I've bumped to the latest stable 1.7.4.

https://pypi.org/project/substrate-interface/