### PR TITLE
TaskHandler, New setting 'VOTE_WITH_BALANCE' & adjusting schedule timing to sync_embeds()

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -30,23 +30,26 @@ DISCORD_EXTRINSIC_ROLE='The role you want to use to notify when a vote has been 
 DISCORD_ANONYMOUS_MODE=True
 
 ###### [ Network Settings ] ########################
-NETWORK_NAME='kusama'
+NETWORK_NAME='polkadot'
 SYMBOL='KSM'
 
 # Polkadot: 1e10 (10 decimals)
 # Kusama:   1e12 (12 decimals)
-TOKEN_DECIMAL=1e12
+TOKEN_DECIMAL=1e10
 
 # RPC address (IBP favoured for stability)
-SUBSTRATE_WSS=wss://rpc.ibp.network/kusama
-PEOPLE_WSS='wss://sys.ibp.network/people-kusama'
+SUBSTRATE_WSS=wss://rpc.ibp.network/polkadot
+PEOPLE_WSS='wss://sys.ibp.network/people-polkadot'
 
 ###### [ Wallet Settings ] ########################
-# when solo mode is set to True, automatic voting is disabled.
+# SOLO_MODE=True automatic voting will be disabled.
+# VOTE_WITH_BALANCE=0 will vote using the entire balance of the
+# proxied address.
 SOLO_MODE=False
 PROXIED_ADDRESS='Address that the gov proxy controls'
 PROXY_ADDRESS='Gov proxy address'
 MNEMONIC='Mnemonic to the governance proxy address'
+# When VOTE_WITH_BALANCE is set to 0, the bot/governance proxy will vote with the entire balance
 VOTE_WITH_BALANCE=1
 
 # This option can be set to Locked1,2,3,4,5,6x
@@ -55,10 +58,10 @@ CONVICTION='Locked4x'
 # This allows you to receive a wallet balance alert to a specific channel
 # and at what balance to issue an alert at.
 DISCORD_PROXY_BALANCE_ALERT='0'
-PROXY_BALANCE_ALERT=0.015
+PROXY_BALANCE_ALERT=1.1
 
 # This setting allows you to set minimum participation percentage
 # internally. If 90 people have DISCORD_VOTER_ROLE and only 6 people
 # vote, then the default decision will be abstain.
 # OPTIONAL: (Set to 0 to turn off minimum participation)
-MIN_PARTICIPATION=12.8
+MIN_PARTICIPATION=0

--- a/.env.sample
+++ b/.env.sample
@@ -21,7 +21,7 @@ DISCORD_TITLE_MAX_LENGTH=95
 DISCORD_BODY_MAX_LENGTH=2000
 
 # This role notifies when a new proposal is on the network.
-DISCORD_NOTIFY_ROLE='KSM-GOV'
+DISCORD_NOTIFY_ROLE='DOT-GOV'
 
 # This role notifies when a vote has been cast onchain.
 DISCORD_EXTRINSIC_ROLE='The role you want to use to notify when a vote has been cast onchain'
@@ -31,7 +31,7 @@ DISCORD_ANONYMOUS_MODE=True
 
 ###### [ Network Settings ] ########################
 NETWORK_NAME='polkadot'
-SYMBOL='KSM'
+SYMBOL='DOT'
 
 # Polkadot: 1e10 (10 decimals)
 # Kusama:   1e12 (12 decimals)

--- a/bot/governance_monitor.py
+++ b/bot/governance_monitor.py
@@ -508,8 +508,6 @@ class GovernanceMonitor(discord.Client):
                     name=thread_title,
                     content=thread_content
                 )
-                self.logger.info(f"Title updated from None -> {title} in vote_counts.json")
-                self.logger.info("Discord thread successfully amended")
             else:
                 self.logger.error(f"Invalid operation or missing parameters for {operation}")
         except Exception as e:

--- a/bot/main.py
+++ b/bot/main.py
@@ -613,7 +613,7 @@ async def recheck_proposals():
                         client=client
                     )
                     thread_channel = channel.get_thread(int(message_id))
-                    await thread_channel.send(content=f'**Was:**\n`{title_from_vote_counts}`\n\n**Now:**\n`{title_from_api}`')
+                    await thread_channel.send(content=f'Before the thread title was changed, it was:\n**{title_from_vote_counts}**')
                     logging.info(f"Title updated from {title_from_vote_counts} -> {title_from_api} in vote_counts.json")
                     logging.info(f"Discord thread successfully amended")
                 except Exception as e:

--- a/bot/test/scheduled_tasks.py
+++ b/bot/test/scheduled_tasks.py
@@ -69,7 +69,6 @@ async def start_tasks(coroutine_task):
     for task in coroutine_task:
         try:
             if not task.is_running():
-                # Start the task before accessing its name
                 print(f"{get_timestamp()} - Starting task, please wait...")
                 task.start()
         except Exception as e:
@@ -119,7 +118,7 @@ async def sync_embeds():
         await start_tasks([recheck_proposals])
 
 
-@tasks.loop(hours=2)
+@tasks.loop(hours=1)
 async def recheck_proposals():
     try:
         task_name = recheck_proposals.get_task().get_name()

--- a/bot/test/scheduled_tasks.py
+++ b/bot/test/scheduled_tasks.py
@@ -1,10 +1,12 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from dotenv import load_dotenv
 import random
 import asyncio
 import discord
 from discord.ext import commands, tasks
+from discord.ext.tasks import Loop
+from asyncio import coroutine
 
 intents = discord.Intents.default()
 bot = commands.Bot(command_prefix="!", intents=intents)
@@ -21,114 +23,123 @@ def get_timestamp():
     return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
 
-def evaluate_task_schedule(task1, task2, minutes=2):
+async def evaluate_task_schedule(self, task: Loop, minutes: int = 2) -> bool:
     """
-    Output the next run times for the given tasks and check if they are within 2 minutes of each other.
+    Evaluates the given task and checks whether the task's next iteration is scheduled
+    within a specific time gap. By default, this function checks if the next iteration of
+    the task is within 2 minutes from the current time.
 
     Args:
-        task1: The first task to check.
-        task2: The second task to check.
+        task (discord.ext.tasks.Loop): The task to evaluate.
+        minutes (int, optional): The time gap in minutes to check. Default is 2 minutes.
+
+    Returns:
+        bool: True if the next iteration of the task is within the given minutes from
+              the current time, else False.
+
+    Note: This function also has a side-effect of stopping the task if the next iteration
+    of the task is within the given minutes from the current time.
     """
-    task1_next_run = task1.next_iteration
-    task2_next_run = task2.next_iteration
+    current_time_utc = datetime.now(timezone.utc)
 
-    if task1_next_run and task2_next_run:
-        task1_str = task1_next_run.strftime('%Y-%m-%d %H:%M:%S')
-        task2_str = task2_next_run.strftime('%Y-%m-%d %H:%M:%S')
-
-        print(f"* {task2.get_task().get_name()} next schedule: {task2_str}")
-        print(f"* {task1.get_task().get_name()} next schedule: {task1_str}")
+    if current_time_utc and task.next_iteration:
 
         # Check if the runs are within 2 minutes (default) of each other
-        time_difference = abs((task1_next_run - task2_next_run).total_seconds())
+        time_difference = abs((current_time_utc - task.next_iteration).total_seconds())
+
         if time_difference <= minutes * 60:
-            print(f"{get_timestamp()} - The tasks are scheduled within 20 minutes of each other. Time difference: {time_difference / 60} minutes.")
+            print(f"The tasks are scheduled within 20 minutes of each other. Time difference: {time_difference / 60:.2f} minutes.")
+            await self.stop_tasks([task])
             return True
 
 
+@staticmethod
 async def stop_tasks(coroutine_task):
     """
     Stops specified asynchronous tasks if they are currently running.
+
+    This function iterates through a list of predefined tasks. For each task, it checks if the task is running and, if so, attempts to stop it.
     """
     for task in coroutine_task:
         try:
             if task.is_running():
                 task = task.get_task()
-                print(f"{get_timestamp()} - Stopping {task.get_name()}, please wait...")
+                print(f"Stopping tasks [{task.get_name()}]")
                 task.cancel()
-                await asyncio.wait([task])
         except Exception as e:
-            task_name = task.get_task().get_name() if task.get_task() else "Unknown"
-            print(f"Error stopping {task_name} task: {e}")
+            print(f"Error stopping {task.get_task().get_name()} task: {e}")
 
 
+@staticmethod
 async def start_tasks(coroutine_task):
     """
     Restarts specified asynchronous tasks if they are not already running.
+
+    This function iterates through a list of predefined tasks. For each task, it checks if the task is not running and, if so, attempts to start it. It logs the start of each task. If an exception occurs while starting a task, it logs the error.
     """
     for task in coroutine_task:
         try:
             if not task.is_running():
-                print(f"{get_timestamp()} - Starting task, please wait...")
                 task.start()
         except Exception as e:
-            task_name = task.get_task().get_name() if task.get_task() else "Unknown"
-            print(f"Error starting {task_name} task: {e}")
+            print(f"Error starting {task.get_task().get_name()} task: {e}")
 
 
-@tasks.loop(hours=3)
+@tasks.loop(minutes=3)
 async def check_governance():
     try:
-        await stop_tasks(coroutine_task=[sync_embeds, recheck_proposals])
+        print("\n")
+        await evaluate_task_schedule(autonomous_voting)
+        await stop_tasks([sync_embeds, recheck_proposals])
         task_name = check_governance.get_task().get_name()
         print(f"{get_timestamp()} - [{task_name}] is running")
-
-        evaluated_time = evaluate_task_schedule(autonomous_voting, check_governance)
-        if evaluated_time:
-            await stop_tasks([autonomous_voting])
-
-        await asyncio.sleep(20)
+        await asyncio.sleep(3)
+        print(f"{get_timestamp()} - 1 new proposal found")
+        await asyncio.sleep(random.uniform(0.1, 25.0))
+        print(f"{get_timestamp()} - Thread created")
+        await asyncio.sleep(random.uniform(0.1, 5.0))
     finally:
-        await start_tasks([autonomous_voting])
+        await start_tasks([autonomous_voting, sync_embeds, recheck_proposals])
+        print("\n")
 
 
-@tasks.loop(hours=6)
+@tasks.loop(minutes=12)
 async def autonomous_voting():
     try:
-        await stop_tasks(coroutine_task=[sync_embeds, recheck_proposals])
+        await stop_tasks([sync_embeds, recheck_proposals])
         task_name = autonomous_voting.get_task().get_name()
         print(f"{get_timestamp()} - [{task_name}] is running")
-        for i in range(0, 60):
-            print(f"Voting on: {i}")
-            await asyncio.sleep(random.uniform(0.1, 2.0))
+        for i in range(0, 5):
+            print(f"{get_timestamp()} - Voting on: {i}")
+            await asyncio.sleep(random.uniform(0.1, 5.0))
     finally:
         await start_tasks([sync_embeds, recheck_proposals])
+        print("\n")
 
 
-@tasks.loop(hours=2)
+@tasks.loop(minutes=1)
 async def sync_embeds():
     try:
-        await stop_tasks(coroutine_task=[recheck_proposals])
+        await stop_tasks([recheck_proposals])
         task_name = sync_embeds.get_task().get_name()
         print(f"{get_timestamp()} - [{task_name}] is running.")
-        for i in range (0, 60):
-            print(f"Synchronizing: {i}")
-            await asyncio.sleep(random.uniform(0.1, 2.0))
+        for i in range (0, 5):
+            print(f"{get_timestamp()} - Synchronizing: {i}")
+            await asyncio.sleep(random.uniform(0.1, 5.0))
     finally:
         await start_tasks([recheck_proposals])
+        print("\n")
 
 
-@tasks.loop(hours=1)
+@tasks.loop(minutes=1)
 async def recheck_proposals():
-    try:
-        task_name = recheck_proposals.get_task().get_name()
-        print(f"{get_timestamp()} - [{task_name}] is running")
-        for i in range (0, 60):
-            print(f"Rechecking proposal: {i}")
-            await asyncio.sleep(random.uniform(0.1, 1))
-    finally:
-        pass
+    task_name = recheck_proposals.get_task().get_name()
+    print(f"{get_timestamp()} - [{task_name}] is running")
 
+    for i in range (0, 5):
+        print(f"{get_timestamp()} - Rechecking proposal: {i}")
+        await asyncio.sleep(random.uniform(0.1, 5.0))
+    print("\n")
 
 @autonomous_voting.before_loop
 async def before_voting():

--- a/bot/test/scheduled_tasks.py
+++ b/bot/test/scheduled_tasks.py
@@ -1,0 +1,159 @@
+import os
+from datetime import datetime
+from dotenv import load_dotenv
+import random
+import asyncio
+import discord
+from discord.ext import commands, tasks
+
+intents = discord.Intents.default()
+bot = commands.Bot(command_prefix="!", intents=intents)
+
+# Load the .env file
+load_dotenv()
+
+# Get the DISCORD_TOKEN from the environment
+discord_token = os.getenv('DISCORD_TOKEN')
+
+
+def get_timestamp():
+    """Returns the current timestamp in a readable format."""
+    return datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+
+def evaluate_task_schedule(task1, task2, minutes=2):
+    """
+    Output the next run times for the given tasks and check if they are within 2 minutes of each other.
+
+    Args:
+        task1: The first task to check.
+        task2: The second task to check.
+    """
+    task1_next_run = task1.next_iteration
+    task2_next_run = task2.next_iteration
+
+    if task1_next_run and task2_next_run:
+        task1_str = task1_next_run.strftime('%Y-%m-%d %H:%M:%S')
+        task2_str = task2_next_run.strftime('%Y-%m-%d %H:%M:%S')
+
+        print(f"* {task2.get_task().get_name()} next schedule: {task2_str}")
+        print(f"* {task1.get_task().get_name()} next schedule: {task1_str}")
+
+        # Check if the runs are within 2 minutes (default) of each other
+        time_difference = abs((task1_next_run - task2_next_run).total_seconds())
+        if time_difference <= minutes * 60:
+            print(f"{get_timestamp()} - The tasks are scheduled within 20 minutes of each other. Time difference: {time_difference / 60} minutes.")
+            return True
+
+
+async def stop_tasks(coroutine_task):
+    """
+    Stops specified asynchronous tasks if they are currently running.
+    """
+    for task in coroutine_task:
+        try:
+            if task.is_running():
+                task = task.get_task()
+                print(f"{get_timestamp()} - Stopping {task.get_name()}, please wait...")
+                task.cancel()
+                await asyncio.wait([task])
+        except Exception as e:
+            task_name = task.get_task().get_name() if task.get_task() else "Unknown"
+            print(f"Error stopping {task_name} task: {e}")
+
+
+async def start_tasks(coroutine_task):
+    """
+    Restarts specified asynchronous tasks if they are not already running.
+    """
+    for task in coroutine_task:
+        try:
+            if not task.is_running():
+                # Start the task before accessing its name
+                print(f"{get_timestamp()} - Starting task, please wait...")
+                task.start()
+        except Exception as e:
+            task_name = task.get_task().get_name() if task.get_task() else "Unknown"
+            print(f"Error starting {task_name} task: {e}")
+
+
+@tasks.loop(hours=3)
+async def check_governance():
+    try:
+        await stop_tasks(coroutine_task=[sync_embeds, recheck_proposals])
+        task_name = check_governance.get_task().get_name()
+        print(f"{get_timestamp()} - [{task_name}] is running")
+
+        evaluated_time = evaluate_task_schedule(autonomous_voting, check_governance)
+        if evaluated_time:
+            await stop_tasks([autonomous_voting])
+
+        await asyncio.sleep(20)
+    finally:
+        await start_tasks([autonomous_voting])
+
+
+@tasks.loop(hours=6)
+async def autonomous_voting():
+    try:
+        await stop_tasks(coroutine_task=[sync_embeds, recheck_proposals])
+        task_name = autonomous_voting.get_task().get_name()
+        print(f"{get_timestamp()} - [{task_name}] is running")
+        for i in range(0, 60):
+            print(f"Voting on: {i}")
+            await asyncio.sleep(random.uniform(0.1, 2.0))
+    finally:
+        await start_tasks([sync_embeds, recheck_proposals])
+
+
+@tasks.loop(hours=2)
+async def sync_embeds():
+    try:
+        await stop_tasks(coroutine_task=[recheck_proposals])
+        task_name = sync_embeds.get_task().get_name()
+        print(f"{get_timestamp()} - [{task_name}] is running.")
+        for i in range (0, 60):
+            print(f"Synchronizing: {i}")
+            await asyncio.sleep(random.uniform(0.1, 2.0))
+    finally:
+        await start_tasks([recheck_proposals])
+
+
+@tasks.loop(hours=2)
+async def recheck_proposals():
+    try:
+        task_name = recheck_proposals.get_task().get_name()
+        print(f"{get_timestamp()} - [{task_name}] is running")
+        for i in range (0, 60):
+            print(f"Rechecking proposal: {i}")
+            await asyncio.sleep(random.uniform(0.1, 1))
+    finally:
+        pass
+
+
+@autonomous_voting.before_loop
+async def before_voting():
+    autonomous_voting.get_task().set_name('autonomous_governance')
+
+
+@check_governance.before_loop
+async def before_governance():
+    check_governance.get_task().set_name('check_governance')
+
+
+@sync_embeds.before_loop
+async def before_sync_embeds():
+    sync_embeds.get_task().set_name('sync_embeds')
+
+
+@recheck_proposals.before_loop
+async def before_recheck_proposals():
+    recheck_proposals.get_task().set_name('recheck_proposals')
+
+
+@bot.event
+async def on_ready():
+    print(f'Logged in as {bot.user}')
+    await start_tasks([check_governance])
+
+bot.run(discord_token)

--- a/bot/utils/task_handler.py
+++ b/bot/utils/task_handler.py
@@ -1,0 +1,69 @@
+from discord.ext.tasks import Loop
+from datetime import datetime, timezone
+from utils.logger import Logger
+
+logging = Logger()
+
+
+class TaskHandler:
+    def __init__(self):
+        self.logging = Logger()
+
+    async def evaluate_task_schedule(self, task: Loop, minutes: int = 2) -> bool:
+        """
+        Evaluates the given task and checks whether the task's next iteration is scheduled
+        within a specific time gap. By default, this function checks if the next iteration of
+        the task is within 2 minutes from the current time.
+
+        Args:
+            task (discord.ext.tasks.Loop): The task to evaluate.
+            minutes (int, optional): The time gap in minutes to check. Default is 2 minutes.
+
+        Returns:
+            bool: True if the next iteration of the task is within the given minutes from
+                  the current time, else False.
+
+        Note: This function also has a side-effect of stopping the task if the next iteration
+        of the task is within the given minutes from the current time.
+        """
+        current_time_utc = datetime.now(timezone.utc)
+
+        if current_time_utc and task.next_iteration:
+
+            # Check if the runs are within 2 minutes (default) of each other
+            time_difference = abs((current_time_utc - task.next_iteration).total_seconds())
+
+            if time_difference <= minutes * 60:
+                logging.info(f"The tasks are scheduled within 20 minutes of each other. Time difference: {time_difference / 60:.2f} minutes.")
+                await self.stop_tasks([task])
+                return True
+
+    @staticmethod
+    async def stop_tasks(coroutine_task):
+        """
+        Stops specified asynchronous tasks if they are currently running.
+
+        This function iterates through a list of predefined tasks. For each task, it checks if the task is running and, if so, attempts to stop it.
+        """
+        for task in coroutine_task:
+            try:
+                if task.is_running():
+                    task = task.get_task()
+                    logging.info(f"Stopping tasks [{task.get_name()}]")
+                    task.cancel()
+            except Exception as e:
+                logging.error(f"Error stopping {task.get_task().get_name()} task: {e}")
+
+    @staticmethod
+    async def start_tasks(coroutine_task):
+        """
+        Restarts specified asynchronous tasks if they are not already running.
+
+        This function iterates through a list of predefined tasks. For each task, it checks if the task is not running and, if so, attempts to start it. It logs the start of each task. If an exception occurs while starting a task, it logs the error.
+        """
+        for task in coroutine_task:
+            try:
+                if not task.is_running():
+                    task.start()
+            except Exception as e:
+                logging.error(f"Error starting {task.get_task().get_name()} task: {e}")


### PR DESCRIPTION
* new class TaskHandler created
  *  `evaluate_task_schedule(task, minutes)` - Used to evaluate if `autonomous_voting` is about to run within 2 minutes of `check_governance` 
  * `stop_tasks()` & `start_tasks()` moved from `main.py` into `utils/task_handler.py`
* New setting `VOTE_WITH_BALANCE` added. 
  * If set to 0, the governance proxy will vote with the entire balance. This setting is useful in cases where the delegate address is used for something other than just receiving delegations and voting in opengov. To ensure the entire balance doesn't get locked up.
 * `sync_embeds()` scheduled time moved from every 2 hrs to 1 after changes to RPC querying has made the process much quicker.
 * The bot will set it's presence to how many active referendums are on the network