### PR TITLE
Error processing referendum 1384

### DIFF
--- a/bot/utils/data_processing.py
+++ b/bot/utils/data_processing.py
@@ -45,6 +45,9 @@ class Text:
         markdown_text = re.sub(r'(?:\s*\n){3,}', '\n\n', markdown_text)  # Replace three or more newlines with optional spaces with just one newline
         markdown_text = markdown_text.rstrip('\n')  # Remove trailing line breaks
 
+        if len(markdown_text) == 0:
+            return "Unable to retrieve content"
+
         return markdown_text
 
     @staticmethod


### PR DESCRIPTION
### **Error:**
```GovernanceMonitor.manage_discord_thread:Failed to manage Discord thread: 400 Bad Request (error code: 50006): Cannot send an empty message```

### **Cause:**
Fetching data for referendum 1384 - JSON key `['content']` contained no data at all on Polkassembly/Subsquare, which caused the error above. When creating a thread in Discord, the body of the thread must contain 1 or more characters.

### **Solution:**
if the length of ['content'] = 0: return "Unable to retrieve content".

---

![image](https://github.com/user-attachments/assets/d3c47387-c861-49d8-a292-51266d511809)
