### PR TITLE
escape_underscores & escape_asterisks set to False when converting ma…

### DIFF
--- a/bot/utils/data_processing.py
+++ b/bot/utils/data_processing.py
@@ -24,12 +24,8 @@ class Text:
             link_text = match.group(1)
             url = match.group(2)
 
-            # Check if the URL is relative
             if url.startswith("../"):
-                # Construct the absolute URL
                 url = base_url + url[3:]
-
-            # If the URL is just a positive integer, it's considered relative
             elif url.isdigit():
                 url = base_url + "referenda/referendum/" + url
 
@@ -39,11 +35,15 @@ class Text:
             url = match.group(1)
             return url
 
-        markdown_text = markdownify.markdownify(markdown_text)
+        # By default, markdownify adds backslashes before _ and * characters
+        # We turn this off by setting escape_underscores and escape_asterisks to False
+        # This keeps URLs clean and prevents unwanted backslashes from appearing
+        markdown_text = markdownify.markdownify(markdown_text, escape_underscores=False, escape_asterisks=False)
+
         markdown_text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', replacer_link, markdown_text)
         markdown_text = re.sub(r'!\[[^\]]*\]\(([^)]+)\)', replacer_image, markdown_text)
         markdown_text = re.sub(r'(?:\s*\n){3,}', '\n\n', markdown_text)  # Replace three or more newlines with optional spaces with just one newline
-        markdown_text = markdown_text.rstrip('\n')  # Remove trailing line breaks
+        markdown_text = markdown_text.rstrip('\n')                                   # Remove trailing line breaks
 
         if len(markdown_text) == 0:
             return "Unable to retrieve content"


### PR DESCRIPTION
Discovered by: [0xTaylor](https://github.com/x676f64)

---

##### `utils\data_processing.py`
- escape_underscores & escape_asterisks set to False when converting markdown to discord 

### **Issue:**
On referendum 1439, the URL to the google document would break due to the underscore between `17MvO1gjD_K-t35TInuRir2PfW25dacG9dp4JcqOZbsE`. When processing the contents through `convert_markdown_to_discord()`, markdownify would add a backslash before the underscore. 

### **Resolution:**
`escape_underscore=False` - If set to False, do not escape `*` to `\*` in text. Defaults to True.
:white_check_mark: <https://docs.google.com/document/d/17MvO1gjD_K-t35TInuRir2PfW25dacG9dp4JcqOZbsE/edit?usp=sharing>
:x: <https://docs.google.com/document/d/17MvO1gjD\_K-t35TInuRir2PfW25dacG9dp4JcqOZbsE/edit?usp=sharing>  

`escape_asterisk=False` - If set to False, do not escape `_` to `\_` in text. Defaults to True.

**Before**
![image](https://github.com/user-attachments/assets/2977d91a-fd43-40c5-a01e-03a0de65f838)

**After**
![image](https://github.com/user-attachments/assets/53ce00c1-bf1d-41ae-b138-bf031246ceea)
