### PR TITLE
added 5 second timeout to SubstrateInterface()

### DIFF
--- a/bot/utils/subquery.py
+++ b/bot/utils/subquery.py
@@ -25,7 +25,9 @@ class SubstrateAPI:
             try:
                 if not self.substrate:
                     self.logger.info(f"{caller_info} - Initializing SubstrateInterface object: {wss}")
-                    self.substrate = SubstrateInterface(url=wss)
+                    self.substrate = SubstrateInterface(url=wss, ws_options={
+                        'timeout': 5
+                    })
 
                     await asyncio.wait_for(
                         asyncio.to_thread(


### PR DESCRIPTION

##### `bot\utils\subquery.py`
- Added 5 second timeout to SubstrateInterface() object to mitigate Shard ID None heartbeat blocked for more than 10 seconds which often results in 'failed interaction'.