### PR TITLE
feat: add threshold param to env config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -67,3 +67,19 @@ PROXY_BALANCE_ALERT=1.1
 # vote, then the default decision will be abstain.
 # OPTIONAL: (Set to 0 to turn off minimum participation)
 MIN_PARTICIPATION=0
+
+
+
+# This setting defines THRESHOLD betwen AYE and NAY votes 
+# to select quorum decision
+#         aye_percentage = aye_votes / total_votes
+#        nay_percentage = nay_votes / total_votes
+#       if aye_percentage >= threshold:
+#           return "aye"
+#       elif nay_percentage >= threshold:
+#           return "nay"
+# If set to 0, then 0.66 used.
+# Example: if set to 0.51 
+# deicion with any bigger amount of votes will be selected 
+# as soon as MIN_PARTICIPATION reached
+THRESHOLD=0

--- a/bot/governance_monitor.py
+++ b/bot/governance_monitor.py
@@ -770,6 +770,9 @@ class GovernanceMonitor(discord.Client):
         """ Calculate and return the result of a vote based on 'aye' and 'nay' counts. """
         total_votes = aye_votes + nay_votes
 
+        if self.config.THRESHOLD > 0:
+            threshold = self.config.THRESHOLD
+
         # Default to abstain if the turnout internally is <= config.MIN_PARTICIPATION
         # Set to 0 to turn off this feature
         if self.config.MIN_PARTICIPATION > 0:

--- a/bot/utils/config.py
+++ b/bot/utils/config.py
@@ -42,6 +42,7 @@ class Config:
             self.DISCORD_PROXY_BALANCE_ALERT = int(os.getenv('DISCORD_PROXY_BALANCE_ALERT') or self.raise_error("Missing DISCORD_PROXY_BALANCE_ALERT"))
             self.PROXY_BALANCE_ALERT = float(os.getenv('PROXY_BALANCE_ALERT') or self.raise_error("Missing PROXY_BALANCE_ALERT"))
             self.MIN_PARTICIPATION = float(os.getenv('MIN_PARTICIPATION') or self.raise_error("Missing MIN_PARTICIPATION"))
+            self.THRESHOLD = float(os.getenv('THRESHOLD') or self.raise_error("Missing THRESHOLD"))
 
         except ValueError as e:
             print(f"Error: {e}")


### PR DESCRIPTION
Currently threshold is set to 0.66 as a default param inside the code and can't be configured. This PR introduces threshold ENV param that allows to explicitly set threshold. 