### PR TITLE
changes for assethub

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,7 +23,7 @@ DISCORD_TITLE_MAX_LENGTH=95
 DISCORD_BODY_MAX_LENGTH=2000
 
 # This role notifies when a new proposal is on the network.
-DISCORD_NOTIFY_ROLE='DOT-GOV'
+DISCORD_NOTIFY_ROLE='KSM-GOV'
 
 # This role notifies when a vote has been cast onchain.
 DISCORD_EXTRINSIC_ROLE='The role you want to use to notify when a vote has been cast onchain'
@@ -32,16 +32,18 @@ DISCORD_EXTRINSIC_ROLE='The role you want to use to notify when a vote has been 
 DISCORD_ANONYMOUS_MODE=True
 
 ###### [ Network Settings ] ########################
-NETWORK_NAME='polkadot'
-SYMBOL='DOT'
+NETWORK_NAME='kusama'
+SYMBOL='KSM'
+EXPLORER_URL='assethub-polkadot.subscan.io'
 
 # Polkadot: 1e10 (10 decimals)
 # Kusama:   1e12 (12 decimals)
-TOKEN_DECIMAL=1e10
+TOKEN_DECIMAL=1e12
 
 # RPC address (IBP favoured for stability)
-SUBSTRATE_WSS='wss://polkadot.dotters.network'
-PEOPLE_WSS='wss://people-polkadot.dotters.network'
+SUBSTRATE_WSS='wss://asset-hub-kusama.dotters.network'
+RELAY_WSS='wss://kusama.dotters.network'
+PEOPLE_WSS='wss://people-kusama.dotters.network'
 
 ###### [ Wallet Settings ] ########################
 # SOLO_MODE=True automatic voting will be disabled.
@@ -67,8 +69,6 @@ PROXY_BALANCE_ALERT=1.1
 # vote, then the default decision will be abstain.
 # OPTIONAL: (Set to 0 to turn off minimum participation)
 MIN_PARTICIPATION=0
-
-
 
 # This setting defines THRESHOLD betwen AYE and NAY votes 
 # to select quorum decision

--- a/bot/governance_monitor.py
+++ b/bot/governance_monitor.py
@@ -36,7 +36,7 @@ class GovernanceMonitor(discord.Client):
         self.tree.copy_global_to(guild=self.guild)
         await self.tree.sync(guild=self.guild)
 
-    def get_asset_price_v2(self, asset_id, currencies='usd'):
+    async def get_asset_price_v2(self, asset_id, currencies='usd'):
         """
         Fetches the price of an asset in the specified currencies from the CoinGecko API.
 
@@ -561,7 +561,7 @@ class GovernanceMonitor(discord.Client):
                     results_message = await thread.send("👍 AYE: 0    |    👎 NAY: 0    |    ☯ RECUSE: 0")
 
                 proposal_index = self.vote_counts[message_id]['index']
-                external_links = ExternalLinkButton(proposal_index, self.config.NETWORK_NAME)
+                external_links = ExternalLinkButton(proposal_index, self.config.NETWORK_NAME, self.config.EXPLORER_URL)
 
                 new_results_message = f"👍 AYE: {self.vote_counts[message_id]['aye']}    |    👎 NAY: {self.vote_counts[message_id]['nay']}    |    ☯ RECUSE: {self.vote_counts[message_id]['recuse']}\n" \
                                       f"{self.calculate_vote_result(aye_votes=self.vote_counts[message_id]['aye'], nay_votes=self.vote_counts[message_id]['nay'])}"

--- a/bot/main.py
+++ b/bot/main.py
@@ -79,7 +79,7 @@ async def check_governance():
         if new_referendums:
             logging.info(f"{len(new_referendums)} new proposal(s) found")
             channel = client.get_channel(config.DISCORD_FORUM_CHANNEL_ID)
-            current_price = client.get_asset_price_v2(asset_id=config.NETWORK_NAME)
+            current_price = await client.get_asset_price_v2(asset_id=config.NETWORK_NAME)
 
             # go through each referendum if more than 1 was submitted in the given scheduled time
             for index, values in new_referendums.items():
@@ -135,7 +135,7 @@ async def check_governance():
                     }
                     await asyncio.sleep(0.5)
                     await client.save_vote_counts()
-                    external_links = ExternalLinkButton(index, config.NETWORK_NAME)
+                    external_links = ExternalLinkButton(index, config.NETWORK_NAME, config.EXPLORER_URL)
                     results_message = await channel_thread.send(content=initial_results_message, view=external_links)
 
                     # results_message_id = results_message.id
@@ -416,7 +416,7 @@ async def autonomous_voting():
                 # Craft extrinsic receipt as Discord Embed
                 extrinsic_embed = Embed(color=vote_scheme.color, title=f'An on-chain vote has been cast', description=f'{vote_scheme.emoji} {vote_type.upper()} on proposal **#{proposal_index}**',
                                         timestamp=datetime.now(timezone.utc))
-                extrinsic_embed.add_field(name='Extrinsic hash', value=f'[{short_extrinsic_hash}](https://{config.NETWORK_NAME}.subscan.io/extrinsic/{extrinsic_hash})',
+                extrinsic_embed.add_field(name='Extrinsic hash', value=f'[{short_extrinsic_hash}](https://{config.EXPLORER_URL}/extrinsic/{extrinsic_hash})',
                                           inline=True)
                 extrinsic_embed.add_field(name=f'Origin', value=f"{data['origin']}", inline=True)
                 extrinsic_embed.add_field(name=f'Vote count', value=f'{vote_count} out of 2', inline=True)
@@ -431,7 +431,7 @@ async def autonomous_voting():
                 extrinsic_embed.set_footer(text="A second vote is initiated only if the first vote's result is disputed or missed")
 
                 # Send Embed
-                external_links = ExternalLinkButton(proposal_index, config.NETWORK_NAME)
+                external_links = ExternalLinkButton(proposal_index, config.NETWORK_NAME, config.EXPLORER_URL)
                 extrinsic_receipt_message = await discord_thread.send(content=f'<@&{role.id}>', embed=extrinsic_embed, view=external_links)
                 await extrinsic_receipt_message.pin()
 
@@ -446,7 +446,7 @@ async def autonomous_voting():
                         summary_notification_role = await client.create_or_get_role(guild, config.DISCORD_SUMMARY_ROLE)
                         internal_thread = vote_counts[data['thread_id']]
                         summary_channel = client.get_channel(config.DISCORD_SUMMARIZER_CHANNEL_ID)
-                        external_links = ExternalLinkButton(proposal_index, config.NETWORK_NAME)
+                        external_links = ExternalLinkButton(proposal_index, config.NETWORK_NAME, config.EXPLORER_URL)
                         await summary_channel.create_thread(name=f"{proposal_index}: {internal_thread['title'][:config.DISCORD_TITLE_MAX_LENGTH].strip()}",
                                                             content=f"<@&{summary_notification_role.id}>\n<#{data['thread_id']}>",
                                                             embed=extrinsic_embed,
@@ -504,7 +504,7 @@ async def sync_embeds():
         await task_handler.stop_tasks([recheck_proposals])
         referendum_info = await substrate.referendumInfoFor()
         json_data = CacheManager.load_data_from_cache('../data/vote_counts.json')
-        current_price = client.get_asset_price_v2(asset_id=config.NETWORK_NAME)
+        current_price = await client.get_asset_price_v2(asset_id=config.NETWORK_NAME)
 
         if json_data:
             index_msgid = await discord_format.find_msgid_by_index(referendum_info, json_data)
@@ -594,7 +594,7 @@ async def sync_embeds():
                     # Add hyperlinks to results if no components found on message
                     if message.author == client.user and ((message.content.startswith("👍 AYE:") and not config.READ_ONLY) or (message.content.startswith("View proposal details") and config.READ_ONLY)) and not message.components:
                         logging.info("Adding missing hyperlink buttons")
-                        external_links = ExternalLinkButton(index, config.NETWORK_NAME)
+                        external_links = ExternalLinkButton(index, config.NETWORK_NAME, config.EXPLORER_URL)
                         await message.edit(view=external_links)
                         break
 
@@ -818,7 +818,7 @@ if __name__ == '__main__':
 
                     extrinsic_embed = Embed(color=vote_scheme.color, title=f'An on-chain vote has been cast',
                                             description=f'{vote_scheme.emoji} {vote.upper()} on proposal **#{proposal_index}**', timestamp=datetime.now(timezone.utc))
-                    extrinsic_embed.add_field(name='Extrinsic hash',value=f'[{short_extrinsic_hash}](https://{config.NETWORK_NAME}.subscan.io/extrinsic/{extrinsic_hash})', inline=True)
+                    extrinsic_embed.add_field(name='Extrinsic hash',value=f'[{short_extrinsic_hash}](https://{config.EXPLORER_URL}/extrinsic/{extrinsic_hash})', inline=True)
                     extrinsic_embed.add_field(name=f'Origin', value=f"{origin[0]}", inline=True)
                     extrinsic_embed.add_field(name=f'Executed by', value=f'<@{interaction.user.id}>', inline=True)
                     extrinsic_embed.add_field(name='\u200b', value='\u200b', inline=False)
@@ -904,7 +904,7 @@ if __name__ == '__main__':
 
                 extrinsic_embed = Embed(color=vote_scheme.color, title=f'An on-chain vote has been cast',
                                         description=f'{vote_scheme.emoji} {decision.value.upper()} on proposal **#{referendum}**', timestamp=datetime.now(timezone.utc))
-                extrinsic_embed.add_field(name='Extrinsic hash', value=f'[{short_extrinsic_hash}](https://{config.NETWORK_NAME}.subscan.io/extrinsic/{extrinsic_hash})', inline=True)
+                extrinsic_embed.add_field(name='Extrinsic hash', value=f'[{short_extrinsic_hash}](https://{config.EXPLORER_URL}/extrinsic/{extrinsic_hash})', inline=True)
                 extrinsic_embed.add_field(name=f'Executed by', value=f'<@{interaction.user.id}>', inline=True)
                 extrinsic_embed.add_field(name='\u200b', value='\u200b', inline=False)
                 extrinsic_embed.add_field(name=f'Decision', value=f"{decision.value.upper()}", inline=True)

--- a/bot/utils/button_handler.py
+++ b/bot/utils/button_handler.py
@@ -20,11 +20,12 @@ class ButtonHandler(View):
 
 
 class ExternalLinkButton(View):
-    def __init__(self, index, network_name):
+    def __init__(self, index, network_name, explorer):
         super().__init__(timeout=5.0)  # Initialize the parent class
         self.index = index
         self.network_name = network_name
+        self.explorer = explorer
         # External link buttons on row 1
         self.add_item(Button(label="Subsquare", style=discord.ButtonStyle.url, url=f"https://{self.network_name}.subsquare.io/referenda/referendum/{self.index}"))
         self.add_item(Button(label="Polkassembly", style=discord.ButtonStyle.url, url=f"https://{self.network_name}.polkassembly.io/referenda/{self.index}"))
-        self.add_item(Button(label="Subscan", style=discord.ButtonStyle.url, url=f"https://{self.network_name}.subscan.io/referenda_v2/{self.index}"))
+        self.add_item(Button(label="Subscan", style=discord.ButtonStyle.url, url=f"https://{self.explorer}/referenda_v2/{self.index}"))

--- a/bot/utils/config.py
+++ b/bot/utils/config.py
@@ -29,8 +29,10 @@ class Config:
             self.NETWORK_NAME = f"{os.getenv('NETWORK_NAME')}" or self.raise_error("Missing NETWORK_NAME")
             self.SYMBOL = os.getenv('SYMBOL') or self.raise_error("Missing SYMBOL")
             self.TOKEN_DECIMAL = float(os.getenv('TOKEN_DECIMAL') or self.raise_error("Missing TOKEN_DECIMAL"))
+            self.EXPLORER_URL = f"{os.getenv('EXPLORER_URL')}" or self.raise_error("Missing EXPLORER_URL")
             self.SUBSTRATE_WSS = os.getenv('SUBSTRATE_WSS') or self.raise_error("Missing SUBSTRATE_WSS")
-            self.PEOPLE_WSS = os.getenv('PEOPLE_WSS')
+            self.RELAY_WSS = os.getenv('RELAY_WSS') or self.raise_error("Missing RELAY_WSS")
+            self.PEOPLE_WSS = os.getenv('PEOPLE_WSS') or self.raise_error("Missing PEOPLE_WSS")
 
             # Wallet Settings
             self.SOLO_MODE = bool(strtobool(os.getenv('SOLO_MODE', ''))) if os.getenv('SOLO_MODE') is not None else self.raise_error("Missing SOLO_MODE")


### PR DESCRIPTION
- two new entries created in  .env
  - EXPLORER_URL (e.g. `assethub-kusama.subscan.io`)
  - RELAY_WSS (e.g. `wss://kusama.dotters.network`)


- modified `check_referendums()` to filter only new top-level referendums
- modified `get_block_epoch()` to fetch the epoch from the relay chain of when a proposal was submitted.